### PR TITLE
🔥 skip redis `keepAlive`

### DIFF
--- a/apps/shiki.katt.dev/server/v1.ts
+++ b/apps/shiki.katt.dev/server/v1.ts
@@ -36,35 +36,7 @@ type Storage = {
 
 const storage = run((): Storage => {
   if (env.REDIS_URL) {
-    const timeoutMs = 60_000;
-    const redis = new Redis(env.REDIS_URL, {
-      // killing the connection after 10 seconds of inactivity
-      // enables Railway to sleep
-      keepAlive: timeoutMs,
-    });
-
-    redis.on("connect", () => {
-      redis.stream.setTimeout(timeoutMs);
-      console.debug("Connected to redis");
-      redis.stream.on("timeout", () => {
-        console.debug("Redis stream timeout");
-      });
-      redis.stream.on("end", () => {
-        console.debug("Redis stream end");
-      });
-      redis.stream.on("connect", () => {
-        console.debug("Redis stream connect");
-      });
-    });
-    redis.on("error", (error) => {
-      console.error({ error }, "Redis error");
-    });
-    redis.on("close", () => {
-      console.debug("Disconnected from redis");
-    });
-    redis.on("reconnecting", () => {
-      console.debug("Reconnecting to redis");
-    });
+    const redis = new Redis(env.REDIS_URL);
     const redisStorage: Storage = {
       async getHash(hash) {
         const data = await redis.get(hash);


### PR DESCRIPTION
apparently railway was using a public redis url